### PR TITLE
fix[api]: removing bcryptbcrypt==4.2.0 from requirements.txt

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,7 +2,6 @@
 fastapi==0.115.5
 uvicorn==0.32.0
 python-dotenv==1.0.1
-bcrypt==4.2.0
 pydantic==2.9.0
 pydantic[email]==2.9.0
 sqlalchemy==2.0.35


### PR DESCRIPTION
changes:
- removing bcrypt==4.2.0 from requirements.txt